### PR TITLE
Automatically fix up ssh-agent forwarding tmx sessions

### DIFF
--- a/bin/tmx
+++ b/bin/tmx
@@ -52,11 +52,21 @@ function find_unused_client_index() {
     echo "${new_index}"
 }
 
+
+function fix_up_ssh_agent() {
+    local session_auth_sock=$HOME/.ssh/tmx_${base_session}_auth_sock
+    if [ ! -S ${session_auth_sock} ] && [ -S ${SSH_AUTH_SOCK} ]; then
+         ln -sf ${SSH_AUTH_SOCK} ${session_auth_sock}
+    fi
+    echo "${session_auth_sock}"
+}
+
 clone_session="${base_session}_C$(find_unused_client_index "${base_session}")"
+session_auth_sock=$(fix_up_ssh_agent)
 
 # if the base session doesn't already exist, create new empty session
 if ! session_exists "${base_session}"; then
-    tmux new-session -d -s "$base_session"
+    SSH_AUTH_SOCK=${session_auth_sock} tmux new-session -d -s "$base_session"
 fi
 
 if [[ -z "$TMUX" ]]; then  # Not already running under tmux

--- a/config/.zsh/zsh.d/single-ssh-agent.zsh
+++ b/config/.zsh/zsh.d/single-ssh-agent.zsh
@@ -10,6 +10,11 @@ is_ssh_agent_forwarded() {
 }
 is_ssh_agent_forwarded && return 0
 
+# If we are running under tmx with agent forwarding, abort
+is_tmx_agent_forwarded() {
+	[[ "$SSH_AUTH_SOCK" =~ tmx_.*_auth_sock ]]
+}
+is_tmx_agent_forwarded && return 0
 
 # Stash away the original, in case user wants to restore it.
 if [ -n "$SSH_AUTH_SOCK" -a -z "$ORIG_SSH_AUTH_SOCK" ] ; then


### PR DESCRIPTION
Creates a symlink with a known name for each tmx base session